### PR TITLE
Fixed navigation arrow always pointing to the left.

### DIFF
--- a/features/layout/sidebar-navigation/menu-item-button.tsx
+++ b/features/layout/sidebar-navigation/menu-item-button.tsx
@@ -22,7 +22,15 @@ export function MenuItemButton({
     <li className={classNames(styles.listItem, className)}>
       <Button className={styles.anchor} onClick={onClick}>
         {/* eslint-disable-next-line @next/next/no-img-element */}
-        <img className={styles.icon} src={iconSrc} alt={`${text} icon`} />{" "}
+        <img
+          className={`${styles.icon} ${
+            isCollapsed && text == "Collapse"
+              ? styles.iconCollapsed
+              : styles.iconNotCollapsed
+          }`}
+          src={iconSrc}
+          alt={`${text} icon`}
+        />{" "}
         {!isCollapsed && text}{" "}
       </Button>
     </li>

--- a/features/layout/sidebar-navigation/menu-item-link.module.scss
+++ b/features/layout/sidebar-navigation/menu-item-link.module.scss
@@ -29,4 +29,13 @@
 .icon {
   width: space.$s6;
   margin-right: space.$s3;
+  transition: transform 0.2s ease-in-out 0s;
+}
+
+.iconCollapsed {
+  transform: rotate(180deg);
+}
+
+.iconNotCollapsed {
+  transform: rotate(0deg);
 }


### PR DESCRIPTION
Based on `isCollapsed` state, the arrow changes its direction.

Previous behaviour: The arrow always points to the left regardless of the navigation state.
Expected behaviour: When the sidebar navigation is collapsed the arrow of the “Collapse” button should point to the right.
Fixed 👍