### PR TITLE
Changed color for *page info* in `IssueList` component

### DIFF
--- a/features/issues/components/issue-list/issue-list.module.scss
+++ b/features/issues/components/issue-list/issue-list.module.scss
@@ -51,7 +51,7 @@
 }
 
 .pageInfo {
-  color: color.$gray-300;
+  color: color.$gray-700;
   font: font.$text-sm-regular;
 }
 


### PR DESCRIPTION
Previous behaviour: The page info has a wrong (lighter) color than in the design. The contrast is really low this way which is bad for accessibility. See the designs for the correct color.
Expected Behaviour: The text color of page info at the bottom of the issue list should match the design

Fixed 👍