### PR TITLE
Support button opens user's mail app now

### DIFF
--- a/cypress/e2e/navigation.cy.ts
+++ b/cypress/e2e/navigation.cy.ts
@@ -29,6 +29,14 @@ describe("Sidebar Navigation", () => {
       cy.get("nav")
         .contains("Settings")
         .should("have.attr", "href", "/dashboard/settings");
+
+      cy.get("nav")
+        .contains("Support")
+        .should(
+          "have.attr",
+          "href",
+          "mailto:support@prolog-app.com?subject=Support%20Request:",
+        );
     });
 
     it("is collapsible", () => {
@@ -36,7 +44,7 @@ describe("Sidebar Navigation", () => {
       cy.get("nav").contains("Collapse").click();
 
       // check that links still exist and are functionable
-      cy.get("nav").find("a").should("have.length", 5).eq(1).click();
+      cy.get("nav").find("a").should("have.length", 6).eq(1).click();
       cy.url().should("eq", "http://localhost:3000/dashboard/issues");
 
       // check that text is not rendered
@@ -80,7 +88,7 @@ describe("Sidebar Navigation", () => {
       isInViewport("nav");
 
       // check that all links are rendered
-      cy.get("nav").find("a").should("have.length", 5);
+      cy.get("nav").find("a").should("have.length", 6);
 
       // Support button should be rendered but Collapse button not
       cy.get("nav").contains("Support").should("exist");

--- a/features/layout/sidebar-navigation/sidebar-navigation.module.scss
+++ b/features/layout/sidebar-navigation/sidebar-navigation.module.scss
@@ -139,3 +139,7 @@
     display: flex;
   }
 }
+
+.mailAnchor {
+  text-decoration: none;
+}

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -79,12 +79,17 @@ export function SidebarNavigation() {
             ))}
           </ul>
           <ul className={styles.list}>
-            <MenuItemButton
-              text="Support"
-              iconSrc="/icons/support.svg"
-              isCollapsed={isSidebarCollapsed}
-              onClick={() => alert("Support")}
-            />
+            <a
+              className={styles.mailAnchor}
+              href="mailto:support@prolog-app.com?subject=Support%20Request:"
+            >
+              <MenuItemButton
+                text="Support"
+                iconSrc="/icons/support.svg"
+                isCollapsed={isSidebarCollapsed}
+                onClick={() => {}}
+              />
+            </a>
             <MenuItemButton
               text="Collapse"
               iconSrc="/icons/arrow-left.svg"

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -79,7 +79,7 @@ export function SidebarNavigation() {
             ))}
           </ul>
           <ul className={styles.list}>
-            <a
+            {/* <a
               className={styles.mailAnchor}
               href="mailto:support@prolog-app.com?subject=Support%20Request:"
             >
@@ -89,7 +89,15 @@ export function SidebarNavigation() {
                 isCollapsed={isSidebarCollapsed}
                 onClick={() => {}}
               />
-            </a>
+            </a> */}
+            <MenuItemLink
+              href="mailto:support@prolog-app.com?subject=Support%20Request:"
+              iconSrc="/icons/support.svg"
+              text="Support"
+              isCollapsed={isSidebarCollapsed}
+              isActive={false}
+            ></MenuItemLink>
+
             <MenuItemButton
               text="Collapse"
               iconSrc="/icons/arrow-left.svg"


### PR DESCRIPTION
Previous behaviour: Clicking the support button opens an alert. There’s no further interaction or information available.
Expected behaviour: Clicking the “Support” button in the sidebar navigation should open the user’s email app.

Fixed 👍