### PR TITLE
Fix-navigation-logo-when-switching-to-mobile

### DIFF
--- a/features/layout/sidebar-navigation/menu-item-link.tsx
+++ b/features/layout/sidebar-navigation/menu-item-link.tsx
@@ -9,6 +9,7 @@ type MenuItemProps = {
   href: string;
   isActive: boolean;
   isCollapsed: boolean;
+  vieportWidth: number;
 };
 
 export function MenuItemLink({
@@ -17,13 +18,14 @@ export function MenuItemLink({
   iconSrc,
   isActive,
   isCollapsed,
+  vieportWidth,
 }: MenuItemProps) {
   return (
     <li className={classNames(styles.listItem, isActive && styles.active)}>
       <Link className={styles.anchor} href={href}>
         {/* eslint-disable-next-line @next/next/no-img-element */}
         <img className={styles.icon} src={iconSrc} alt={`${text} icon`} />{" "}
-        {!isCollapsed && text}
+        {!isCollapsed || vieportWidth < 1024 ? text : ""}
       </Link>
     </li>
   );

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -23,6 +23,8 @@ export function SidebarNavigation() {
   const [viewportWidth, setViewportWidth] = useState(0);
 
   useEffect(() => {
+    setViewportWidth(window.innerWidth);
+
     window.addEventListener("resize", () =>
       setViewportWidth(window.innerWidth),
     );

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -79,17 +79,6 @@ export function SidebarNavigation() {
             ))}
           </ul>
           <ul className={styles.list}>
-            {/* <a
-              className={styles.mailAnchor}
-              href="mailto:support@prolog-app.com?subject=Support%20Request:"
-            >
-              <MenuItemButton
-                text="Support"
-                iconSrc="/icons/support.svg"
-                isCollapsed={isSidebarCollapsed}
-                onClick={() => {}}
-              />
-            </a> */}
             <MenuItemLink
               href="mailto:support@prolog-app.com?subject=Support%20Request:"
               iconSrc="/icons/support.svg"

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from "next/router";
-import { useContext, useState } from "react";
+import { useContext, useEffect, useState } from "react";
 import { Routes } from "@config/routes";
 import classNames from "classnames";
 import { NavigationContext } from "./navigation-context";
@@ -20,6 +20,14 @@ export function SidebarNavigation() {
   const router = useRouter();
   const { isSidebarCollapsed, toggleSidebar } = useContext(NavigationContext);
   const [isMobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const [viewportWidth, setViewportWidth] = useState(0);
+
+  useEffect(() => {
+    window.addEventListener("resize", () =>
+      setViewportWidth(window.innerWidth),
+    );
+  }, []);
+
   return (
     <div
       className={classNames(
@@ -37,7 +45,7 @@ export function SidebarNavigation() {
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
             src={
-              isSidebarCollapsed
+              isSidebarCollapsed && viewportWidth > 1024
                 ? "/icons/logo-small.svg"
                 : "/icons/logo-large.svg"
             }
@@ -75,6 +83,7 @@ export function SidebarNavigation() {
                 {...menuItem}
                 isCollapsed={isSidebarCollapsed}
                 isActive={router.pathname === menuItem.href}
+                vieportWidth={viewportWidth}
               />
             ))}
           </ul>
@@ -85,6 +94,7 @@ export function SidebarNavigation() {
               text="Support"
               isCollapsed={isSidebarCollapsed}
               isActive={false}
+              vieportWidth={viewportWidth}
             ></MenuItemLink>
 
             <MenuItemButton


### PR DESCRIPTION
On mobile the header always show the large logo.
Fixed this issue based on `isSidebarCollapsed` prop and `viewportWidth`