### PR TITLE
Fixed project list status and colours

### DIFF
--- a/api/projects.types.ts
+++ b/api/projects.types.ts
@@ -5,9 +5,9 @@ export enum ProjectLanguage {
 }
 
 export enum ProjectStatus {
-  stable = "stable",
+  info = "stable",
   warning = "warning",
-  critical = "critical",
+  error = "critical",
 }
 
 export type Project = {

--- a/cypress/e2e/project-list.cy.ts
+++ b/cypress/e2e/project-list.cy.ts
@@ -1,5 +1,6 @@
 import capitalize from "lodash/capitalize";
 import mockProjects from "../fixtures/projects.json";
+import { ProjectStatus } from "@api/projects.types";
 
 describe("Project List", () => {
   beforeEach(() => {
@@ -32,7 +33,12 @@ describe("Project List", () => {
           cy.wrap($el).contains(languageNames[index]);
           cy.wrap($el).contains(mockProjects[index].numIssues);
           cy.wrap($el).contains(mockProjects[index].numEvents24h);
-          cy.wrap($el).contains(capitalize(mockProjects[index].status));
+          const currentStatus = mockProjects[index].status;
+          cy.wrap($el).contains(
+            capitalize(
+              ProjectStatus[currentStatus as keyof typeof ProjectStatus],
+            ),
+          );
           cy.wrap($el)
             .find("a")
             .should("have.attr", "href", "/dashboard/issues");

--- a/features/projects/components/project-card/project-card.stories.tsx
+++ b/features/projects/components/project-card/project-card.stories.tsx
@@ -26,7 +26,7 @@ Default.args = {
     language: ProjectLanguage.react,
     numIssues: 420,
     numEvents24h: 721,
-    status: ProjectStatus.critical,
+    status: ProjectStatus.error,
   },
 };
 Default.parameters = {

--- a/features/projects/components/project-card/project-card.tsx
+++ b/features/projects/components/project-card/project-card.tsx
@@ -17,9 +17,9 @@ const languageNames = {
 };
 
 const statusColors = {
-  [ProjectStatus.stable]: BadgeColor.success,
+  [ProjectStatus.info]: BadgeColor.success,
   [ProjectStatus.warning]: BadgeColor.warning,
-  [ProjectStatus.critical]: BadgeColor.error,
+  [ProjectStatus.error]: BadgeColor.error,
 };
 
 export function ProjectCard({ project }: ProjectCardProps) {
@@ -50,7 +50,15 @@ export function ProjectCard({ project }: ProjectCardProps) {
             <div className={styles.issuesNumber}>{numEvents24h}</div>
           </div>
           <div className={styles.status}>
-            <Badge color={statusColors[status]}>{capitalize(status)}</Badge>
+            <Badge
+              color={
+                statusColors[
+                  ProjectStatus[status as keyof typeof ProjectStatus]
+                ]
+              }
+            >
+              {capitalize(ProjectStatus[status as keyof typeof ProjectStatus])}
+            </Badge>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Previous behaviour:
* The colors for status “Error” and “Info” aren’t shown according to the design.
* The text writes “Error” instead of “Critical” and “Info” instead of “Stable”

Expected behaviour:
* The colors should be red, yellow, or green
* The text should show “Critical”, “Warning”, or “Stable”

Fixed 👍